### PR TITLE
Add HTTP Cookie to Handsoap::Service

### DIFF
--- a/lib/handsoap/service.rb
+++ b/lib/handsoap/service.rb
@@ -67,7 +67,21 @@ module Handsoap
     end
   end
 
-  CurlResponse = Struct.new(:content, :headers)
+  CurlResponse = Struct.new(:content, :raw_headers) do
+    def headers
+      # split the headers on newlines
+      header_array = raw_headers.split("\n")
+
+      # drop the first HTTP/1.1 200 OK element
+      header_array.shift
+
+      # strip out any leading/trailing whitespace
+      header_array.each { |h| h.strip! }.reject!(&:empty?)
+
+      # split e.g.: 'Content-Length: 100' to create a hash
+      header_array.collect { |h| h.split(": ") }.to_h
+    end
+  end
 
   class Fault < RuntimeError
     attr_reader :code, :reason, :details


### PR DESCRIPTION
Add a cookie to Handsoap::Service if one is returned from the server in the http headers.

This will allow us to extract the VC Session Token from the Vim connection to be used with other services' connection (e.g.: [SPBM](https://www.vmware.com/support/developer/vc-sdk/spbm-sdk/))

This method mimics how [RbVmomi](https://github.com/vmware/rbvmomi) retrieves the session cookie: https://github.com/vmware/rbvmomi/blob/master/lib/rbvmomi/trivial_soap.rb#L102
The session token is used to authenticate the PBM session https://github.com/vmware/rbvmomi/blob/master/lib/rbvmomi/pbm.rb#L32 and can be used for other services in the future (e.g.: [SMS](https://www.vmware.com/support/developer/vc-sdk/sms-sdk/)).
