### PR TITLE
Handle XML responses with excesive depth

### DIFF
--- a/lib/handsoap/service.rb
+++ b/lib/handsoap/service.rb
@@ -47,7 +47,9 @@ module Handsoap
     end
     def document
       if @document == :lazy
-        doc = Nokogiri::XML(@http_response.content)
+        doc = Nokogiri::XML(@http_response.content) do |config|
+          config.options |= Nokogiri::XML::ParseOptions::HUGE
+        end
         @document = (doc && doc.root && doc.errors.empty?) ? doc : nil
       end
       return @document


### PR DESCRIPTION
VMware has been seen to return XML documents with depth that exceeds libxml2's internal checks.  To handle this libxml2 recommends using config option `XML_PARSE_HUGE`

The ability to use this option was added here: https://github.com/sparklemotion/nokogiri/commit/685e0a24f25199c078a2c3f6fc9d0da31db51bf7 original issue: https://github.com/sparklemotion/nokogiri/issues/430
The limit was added to libxml2 in this patch: https://mail.gnome.org/archives/commits-list/2012-August/msg00645.html

https://bugzilla.redhat.com/show_bug.cgi?id=1363761
