### PR TITLE
Save http_body and http_headers separately so that http_body can be cleared by VimService

### DIFF
--- a/lib/handsoap/service.rb
+++ b/lib/handsoap/service.rb
@@ -37,7 +37,8 @@ module Handsoap
 
   class Response
     def initialize(http_response, soap_namespace)
-      @http_response = http_response
+      @http_body = http_response.content
+      @http_headers = http_response.headers
       @soap_namespace = soap_namespace
       @document = :lazy
       @fault = :lazy
@@ -47,7 +48,7 @@ module Handsoap
     end
     def document
       if @document == :lazy
-        doc = Nokogiri::XML(@http_response.content) do |config|
+        doc = Nokogiri::XML(@http_body) do |config|
           config.options |= Nokogiri::XML::ParseOptions::HUGE
         end
         @document = (doc && doc.root && doc.errors.empty?) ? doc : nil
@@ -65,7 +66,7 @@ module Handsoap
       return @fault
     end
     def cookie
-      @http_response.headers['Set-Cookie']
+      @http_headers['Set-Cookie']
     end
   end
 


### PR DESCRIPTION
Split up the http_body and the http_headers parts of the response so that the body can be cleared for memory reclamation.

The `parse_response` method in `VimService` sets the `@http_body` to `nil` and runs GC to help reclaim memory for large xml documents after they have been parsed (https://github.com/ManageIQ/manageiq/blob/master/gems/pending/VMwareWebService/VimService.rb#L1251)

PR https://github.com/ManageIQ/handsoap/pull/3 changed `http_body` to `http_response` to allow the `http_headers` to be queried, without changing the corresponding method in `VimService` so the logic to free the memory was broken.

This adds back the `@http_body` instance variable so that it can be cleared by `VimService` while preserving the `http_headers` so the connection cookie can be queried even after the `http_body` was cleared.

Without this patch PSS memory usage during a refresh peaked at `824623000` and steady state was `770243000`
With this patch PSS memory usage never peaked above the final steady state value of `767448000`
