### PR TITLE
remove deprecated has_rdoc

### DIFF
--- a/handsoap.gemspec
+++ b/handsoap.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
     "lib/handsoap/service.rb",
     "lib/handsoap/xml_mason.rb"
   ]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/troelskn/handsoap}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
fixes: 

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from handsoap-b1247a733ca3/handsoap.gemspec:27.
```

please ensure this is pointing to the right target... `handsoap_0_2_5`

thnx